### PR TITLE
refactor: @JsonRootName 제거

### DIFF
--- a/src/main/java/io/spring/api/article/request/NewArticleParam.java
+++ b/src/main/java/io/spring/api/article/request/NewArticleParam.java
@@ -1,11 +1,9 @@
 package io.spring.api.article.request;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
 import io.spring.application.article.DuplicatedArticleConstraint;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
-@JsonRootName("article")
 public record NewArticleParam(
     @NotBlank(message = "can't be empty") @DuplicatedArticleConstraint String title,
     @NotBlank(message = "can't be empty") String description,

--- a/src/main/java/io/spring/api/article/request/UpdateArticleParam.java
+++ b/src/main/java/io/spring/api/article/request/UpdateArticleParam.java
@@ -1,6 +1,3 @@
 package io.spring.api.article.request;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
-
-@JsonRootName("article")
 public record UpdateArticleParam(String title, String body, String description) {}

--- a/src/main/java/io/spring/api/comment/request/NewCommentParam.java
+++ b/src/main/java/io/spring/api/comment/request/NewCommentParam.java
@@ -1,7 +1,5 @@
 package io.spring.api.comment.request;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
 import jakarta.validation.constraints.NotBlank;
 
-@JsonRootName("comment")
 public record NewCommentParam(@NotBlank(message = "can't be empty") String body) {}

--- a/src/main/java/io/spring/api/exception/ErrorResource.java
+++ b/src/main/java/io/spring/api/exception/ErrorResource.java
@@ -1,14 +1,12 @@
 package io.spring.api.exception;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 
 @JsonSerialize(using = ErrorResourceSerializer.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @lombok.Getter
-@JsonRootName("errors")
 public class ErrorResource {
   private List<FieldErrorResource> fieldErrors;
 

--- a/src/main/java/io/spring/api/user/request/LoginParam.java
+++ b/src/main/java/io/spring/api/user/request/LoginParam.java
@@ -1,10 +1,8 @@
 package io.spring.api.user.request;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-@JsonRootName("user")
 public record LoginParam(
     @NotBlank(message = "can't be empty") @Email(message = "should be an email") String email,
     @NotBlank(message = "can't be empty") String password) {}

--- a/src/main/java/io/spring/api/user/request/RegisterParam.java
+++ b/src/main/java/io/spring/api/user/request/RegisterParam.java
@@ -1,12 +1,10 @@
 package io.spring.api.user.request;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
 import io.spring.application.user.DuplicatedEmailConstraint;
 import io.spring.application.user.DuplicatedUsernameConstraint;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-@JsonRootName("user")
 public record RegisterParam(
     @NotBlank(message = "can't be empty")
         @Email(message = "should be an email")

--- a/src/main/java/io/spring/api/user/request/UpdateUserParam.java
+++ b/src/main/java/io/spring/api/user/request/UpdateUserParam.java
@@ -1,9 +1,7 @@
 package io.spring.api.user.request;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
 import jakarta.validation.constraints.Email;
 
-@JsonRootName("user")
 public record UpdateUserParam(
     @Email(message = "should be an email") String email,
     String password,

--- a/src/main/java/io/spring/application/user/RegisterParam.java
+++ b/src/main/java/io/spring/application/user/RegisterParam.java
@@ -1,10 +1,8 @@
 package io.spring.application.user;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-@JsonRootName("user")
 public record RegisterParam(
     @NotBlank(message = "can't be empty")
         @Email(message = "should be an email")


### PR DESCRIPTION
## Summary

- close #25 

## Tasks

- @JsonRootName 사용으로 인한 JSON 객체 wrapping이 불필요하다는 의견에 따라 제거
- 현재 jackson.WRAP_ROOT_VALUE 제거 및 많은 테스트 코드가 주석처리 되어 커밋 진행
  - 어제 jackson.WRAP_ROOT_VALUE = false 설정하면서 테스트 코드 및 비즈니스 로직 수정이 필요했었음
