### PR TITLE
feat: Add indexing on created_at for performance improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,61 @@
 # ![RealWorld Example App using Kotlin and Spring](example-logo.png)
 
-[![Actions](https://github.com/gothinkster/spring-boot-realworld-example-app/workflows/Java%20CI/badge.svg)](https://github.com/gothinkster/spring-boot-realworld-example-app/actions)
+[![Gradle Build & Test](https://github.com/deepdive-debug/spring-boot-realworld-example-app/actions/workflows/gradle.yml/badge.svg)](https://github.com/deepdive-debug/spring-boot-realworld-example-app/actions/workflows/gradle.yml)
+[![Test Coverage](https://github.com/deepdive-debug/spring-boot-realworld-example-app/actions/workflows/pull-request-test-coverage.yml/badge.svg)](https://github.com/deepdive-debug/spring-boot-realworld-example-app/actions/workflows/pull-request-test-coverage.yml)
+[![Codecov](https://codecov.io/gh/deepdive-debug/spring-boot-realworld-example-app/branch/develop/graph/badge.svg)](https://codecov.io/gh/deepdive-debug/spring-boot-realworld-example-app)
 
-> ### Spring boot + MyBatis codebase containing real world examples (CRUD, auth, advanced patterns, etc) that adheres to the [RealWorld](https://github.com/gothinkster/realworld-example-apps) spec and API.
 
-This codebase was created to demonstrate a fully fledged full-stack application built with Spring boot + Mybatis including CRUD operations, authentication, routing, pagination, and more.
+> ### Spring boot + JPA codebase containing real world examples (CRUD, auth, advanced patterns, etc) that adheres to the [RealWorld](https://github.com/gothinkster/realworld-example-apps) spec and API.
+
+This codebase is ideal for developers looking to:
+- Learn Spring Boot with a focus on best practices.
+- Implement a production-grade backend using JPA and Spring Security.
+- Understand CI/CD workflows and automated deployment processes.
+
+
+This codebase was created to demonstrate a fully fledged full-stack application built with Spring boot + Spring Data JPA including CRUD operations, authentication, routing, pagination, and more.
 
 For more information on how to this works with other frontends/backends, head over to the [RealWorld](https://github.com/gothinkster/realworld) repo.
 
-# *NEW* GraphQL Support  
+---
 
-Following some DDD principles. REST or GraphQL is just a kind of adapter. And the domain layer will be consistent all the time. So this repository implement GraphQL and REST at the same time.
+## Table of Contents
 
-The GraphQL schema is https://github.com/gothinkster/spring-boot-realworld-example-app/blob/master/src/main/resources/schema/schema.graphqls and the visualization looks like below.
+- [How It Works](#how-it-works)
+- [Getting Started](#getting-started)
+- [Local Development Setup](#local-development-setup)
+- [Security](#security)
+- [Database](#database)
+- [API Documentation](#api-documentation)
+- [Try It Out with Docker](#try-it-out-with-docker)
+- [Try It Out with a RealWorld Frontend](#try-it-out-with-a-realworld-frontend)
+- [Run Tests](#run-tests)
+- [Code Format](#code-format)
+- [CI/CD Pipeline Setup](#cicd-pipeline-setup)
+    - [Server Requirements](#1-server-requirements)
+    - [GitHub Actions Secrets](#2-github-actions-secrets)
+    - [Deployment Workflow](#3-deployment-workflow)
+- [Help](#help)
 
-![](graphql-schema.png)
 
-And this implementation is using [dgs-framework](https://github.com/Netflix/dgs-framework) which is a quite new java graphql server framework.
 # How it works
 
-The application uses Spring Boot (Web, Mybatis).
+The application uses Spring Boot (Web, Spring Data JPA).
 
-* Use the idea of Domain Driven Design to separate the business term and infrastructure term.
-* Use MyBatis to implement the [Data Mapper](https://martinfowler.com/eaaCatalog/dataMapper.html) pattern for persistence.
-* Use [CQRS](https://martinfowler.com/bliki/CQRS.html) pattern to separate the read model and write model.
+* **Domain Driven Design (DDD)**: Separates business logic from infrastructure logic.
+* **Spring Data JPA**: Simplifies data access layers, replacing MyBatis.
 
 And the code is organized as this:
 
-1. `api` is the web layer implemented by Spring MVC
-2. `core` is the business model including entities and services
-3. `application` is the high-level services for querying the data transfer objects
-4. `infrastructure`  contains all the implementation classes as the technique details
+1. `api` Handles presentation layer with Spring MVC and Data Transfer Objects (DTOs).
+2. `core` Contains service layer for business logic.
+3. `application` Manages domain entities and repositories.
+4. `infrastructure` Handles configurations and legacy integrations.
 
-# Security
-
-Integration with Spring Security and add other filter for jwt token process.
-
-The secret key is stored in `application.properties`.
-
-# Database
-
-It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without losing test data after every restart), can be changed easily in the `application.properties` for any other database.
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 
@@ -53,22 +64,69 @@ Alternatively, you can run
 
     curl http://localhost:8080/tags
 
+
+# Local Development Setup
+
+To run the project locally, you can configure your environment variables using a `.env` file.
+
+### Example `.env` file
+
+    SPRING_PROFILES_ACTIVE=local
+    DB_HOST=localhost
+    DB_PORT=3306
+    DB_NAME=debug
+    DB_USERNAME=root
+    DB_PASSWORD=password
+
+
+Load the environment variables by placing the `.env` file in the root directory and using a library like `dotenv` in your project.
+
+
+# Security
+
+Integration with Spring Security and add other filter for jwt token process.
+
+The secret key is stored in `application.properties`.
+
+
+# Database
+
+The application uses MySQL for data persistence. You can configure the database in the `application.properties` file.
+For development and local testing, you can easily switch to another database if needed.
+
+
+# API Documentation
+
+Swagger is integrated to provide detailed API documentation.
+After running the application, access Swagger UI at http://localhost:8080/swagger-ui/index.html.
+
+
 # Try it out with [Docker](https://www.docker.com/)
 
 You'll need Docker installed.
-	
+
     ./gradlew bootBuildImage --imageName spring-boot-realworld-example-app
     docker run -p 8081:8080 spring-boot-realworld-example-app
 
 # Try it out with a RealWorld frontend
 
-The entry point address of the backend API is at http://localhost:8080, **not** http://localhost:8080/api as some of the frontend documentation suggests.
+The entry point address of the backend API is at http://localhost:8080, **not** ~~http://localhost:8080/api~~ as some of the frontend documentation suggests.
+
 
 # Run test
 
-The repository contains a lot of test cases to cover both api test and repository test.
+The repository contains a wide range of test cases to cover both API and repository layers.
 
     ./gradlew test
+
+#### Access Test Coverage Reports
+After running the tests, you can access the coverage report.
+- **HTML Report:** Located at `build/reports/tests/test/index.html`.
+- **Codecov Report:** Available at [Codecov Dashboard](https://codecov.io/gh/deepdive-debug/spring-boot-realworld-example-app).
+
+#### Coverage Goals
+This project aims to maintain a minimum of 70% test coverage to ensure code quality and reliability.
+
 
 # Code format
 
@@ -76,6 +134,57 @@ Use spotless for code format.
 
     ./gradlew spotlessJavaApply
 
+
+# CI/CD
+
+This project includes a fully automated CI/CD pipeline to streamline deployment and testing processes. Follow these steps to set up the pipeline.
+
+### 1.	Server Requirements
+- Install Docker and Docker Compose on your server.
+- Configure swap memory if your server has limited resources.
+
+### 2. GitHub Actions Secrets
+Add the following secrets to your GitHub repository under **Settings > Secrets and variables > Actions**.
+
+**General**
+`CODECOV_TOKEN`
+
+**Docker Hub Access**
+`DOCKER_USERNAME`, `DOCKER_PASSWORD`, `DOCKER_COMPOSE_YAML_PATH`
+
+**Server Deployment**
+`SERVER_HOST`, `SERVER_PORT`, `SERVER_SSH_KEY`, `SERVER_USERNAME`
+
+
+### 3. Deployment Workflow
+On every push or pull request, the pipeline will:
+- Build and test the application.
+- Push the Docker image to Docker Hub.
+- Deploy the image to your server using docker-compose.
+
+
 # Help
 
 Please fork and PR to improve the project.
+
+## Contribution Guidelines
+### Branch Strategy
+- Create feature branches using the naming convention `feature/<feature-name>`.
+- Use `refactor/<issue-name>` for refactoring codes.
+
+
+### Commit Message Guidelines
+
+Use the format
+
+    <type>: <subject>
+
+**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+Example: `feat: add user authentication`
+
+
+
+### Pull Request
+- Describe the changes in detail.
+- Link related issues (e.g., `Closes #1`).

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,0 +1,208 @@
+
+# ![RealWorld Example App using Kotlin and Spring](example-logo.png)
+
+[![Gradle Build & Test](https://github.com/deepdive-debug/spring-boot-realworld-example-app/actions/workflows/gradle.yml/badge.svg)](https://github.com/deepdive-debug/spring-boot-realworld-example-app/actions/workflows/gradle.yml)
+[![Test Coverage](https://github.com/deepdive-debug/spring-boot-realworld-example-app/actions/workflows/pull-request-test-coverage.yml/badge.svg)](https://github.com/deepdive-debug/spring-boot-realworld-example-app/actions/workflows/pull-request-test-coverage.yml)
+[![Codecov](https://codecov.io/gh/deepdive-debug/spring-boot-realworld-example-app/branch/develop/graph/badge.svg)](https://codecov.io/gh/deepdive-debug/spring-boot-realworld-example-app)
+
+> ### Spring Boot + JPA 기반의 실무 예제 코드베이스 (CRUD, 인증, 고급 패턴 등)
+[RealWorld](https://github.com/gothinkster/realworld-example-apps) 사양 및 API를 준수합니다.
+
+이 코드베이스는 다음을 배우고자 하는 개발자들에게 적합합니다:
+- Spring Boot를 활용한 최고의 예제 연습.
+- JPA와 Spring Security를 활용한 프로덕션급 백엔드 구현.
+- CI/CD 워크플로우 및 자동 배포 프로세스 이해.
+
+이 프로젝트는 CRUD 작업, 인증, 라우팅, 페이지네이션 등을 포함하는 Spring Boot + Spring Data JPA로 애플리케이션을 구현하는 것을 시연합니다.
+
+다른 프론트엔드/백엔드와의 동작 방식에 대한 자세한 내용은 [RealWorld](https://github.com/gothinkster/realworld) 저장소를 참조하세요.
+
+---
+
+## 목차
+
+- [작동 원리](#작동-원리)
+- [시작하기](#시작하기)
+- [로컬 개발 환경 설정](#로컬-개발-환경-설정)
+- [보안](#보안)
+- [데이터베이스](#데이터베이스)
+- [API 문서](#api-문서)
+- [Docker로 실행하기](#docker로-실행하기)
+- [RealWorld 프론트엔드와 함께 사용하기](#realworld-프론트엔드와-함께-사용하기)
+- [테스트 실행](#테스트-실행)
+- [코드 포맷팅](#코드-포맷팅)
+- [CI/CD 파이프라인 설정](#cicd-파이프라인-설정)
+    - [서버 요구 사항](#1-서버-요구-사항)
+    - [GitHub Actions Secrets](#2-github-actions-secrets)
+    - [배포 워크플로우](#3-배포-워크플로우)
+- [도움말](#도움말)
+- [기여 가이드라인](#기여-가이드라인)
+
+
+
+# 작동 원리
+
+이 애플리케이션은 Spring Boot (Web, Spring Data JPA)를 사용합니다.
+
+* **도메인 주도 설계(DDD)**: 비즈니스 로직과 인프라 로직을 분리합니다.
+* **Spring Data JPA**: MyBatis를 대체하여 데이터 액세스 계층을 단순화합니다.
+
+코드 구조는 다음과 같습니다:
+
+1. `api`: Spring MVC와 DTO(Data Transfer Objects)를 사용하는 프레젠테이션 계층.
+2. `core`: 비즈니스 로직을 처리하는 서비스 계층.
+3. `application`: 도메인 엔티티와 리포지토리를 관리합니다.
+4. `infrastructure`: 구성 및 레거시 코드 (Mybatis 관련).
+
+
+# 시작하기
+
+Java 17이 필요합니다.
+
+```
+./gradlew bootRun
+```
+
+실행 후 [http://localhost:8080/tags](http://localhost:8080/tags)로 브라우저를 열어 테스트하세요.  
+또는 아래 명령어를 실행하세요:
+
+```
+curl http://localhost:8080/tags
+```
+
+
+# 로컬 개발 환경 설정
+
+프로젝트를 로컬에서 실행하려면 `.env` 파일을 사용하여 환경 변수를 설정하세요.
+
+### `.env` 파일 예시
+
+    SPRING_PROFILES_ACTIVE=local
+    DB_HOST=localhost
+    DB_PORT=3306
+    DB_NAME=debug
+    DB_USERNAME=root
+    DB_PASSWORD=password
+
+
+환경 변수는 `.env` 파일을 루트 디렉토리에 배치하고 `dotenv` 같은 라이브러리를 사용하여 로드할 수 있습니다.
+
+
+
+# 보안
+
+Spring Security와 JWT 토큰 처리를 위한 추가 필터가 통합되어 있습니다.  
+비밀 키는 `application.properties`에 저장됩니다.
+
+
+
+# 데이터베이스
+
+이 애플리케이션은 MySQL을 데이터 영속성에 사용합니다.  
+`application.properties` 파일에서 데이터베이스를 구성할 수 있습니다.  
+개발 및 로컬 테스트에서는 다른 데이터베이스로 쉽게 전환할 수 있습니다.
+
+
+
+# API 문서
+
+Swagger가 통합되어 상세한 API 문서를 제공합니다.  
+애플리케이션 실행 후 [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)에서 Swagger UI를 확인하세요.
+
+
+
+# Docker로 실행하기
+
+Docker가 설치되어 있어야 합니다.
+
+
+    ./gradlew bootBuildImage --imageName spring-boot-realworld-example-app
+    docker run -p 8081:8080 spring-boot-realworld-example-app
+
+
+
+
+# RealWorld 프론트엔드와 함께 사용하기
+
+백엔드 API의 엔드포인트는 [http://localhost:8080](http://localhost:8080)입니다.  
+일부 프론트엔드 문서에 명시된 ~~http://localhost:8080/api~~ 는 사용하지 않습니다.
+
+
+
+# 테스트 실행
+
+이 저장소는 API와 리포지토리 계층을 포괄하는 다양한 테스트 케이스를 포함하고 있습니다.
+
+
+    ./gradlew test
+
+
+#### 테스트 커버리지 보고서 확인
+- **HTML 보고서**: `build/reports/tests/test/index.html`에 위치.
+- **Codecov 보고서**: [Codecov 대시보드](https://codecov.io/gh/deepdive-debug/spring-boot-realworld-example-app)에서 확인 가능.
+
+
+#### 커버리지 목표
+이 프로젝트는 코드 품질과 신뢰성을 보장하기 위해 최소 70%의 테스트 커버리지를 유지하는 것을 목표로 합니다.
+
+
+# 코드 포맷팅
+
+Spotless를 사용하여 코드 포맷팅.
+
+    ./gradlew spotlessJavaApply
+
+
+
+# CI/CD 파이프라인 설정
+
+이 프로젝트에는 배포 및 테스트 프로세스를 간소화하기 위한 완전 자동화된 CI/CD 파이프라인이 포함되어 있습니다.  
+다음 단계를 따라 파이프라인을 설정하세요:
+
+### 1. 서버 요구 사항:
+- Docker와 Docker Compose를 서버에 설치하세요.
+- 서버 리소스가 제한적인 경우 스왑 메모리를 구성하세요.
+
+### 2. GitHub Actions Secrets:
+GitHub 저장소에서 **Settings > Secrets and variables > Actions**에 다음 Secrets를 추가하세요.
+
+**일반**
+`CODECOV_TOKEN`
+
+**Docker Hub 액세스**
+`DOCKER_USERNAME`, `DOCKER_PASSWORD`, `DOCKER_COMPOSE_YAML_PATH`
+
+**서버 배포**
+`SERVER_HOST`, `SERVER_PORT`, `SERVER_SSH_KEY`, `SERVER_USERNAME`
+
+
+### 3. 배포 워크플로우:
+푸시 또는 PR(Pull Request) 시 파이프라인이 자동으로 실행됩니다:
+- 애플리케이션을 빌드 및 테스트합니다.
+- Docker 이미지를 Docker Hub에 푸시합니다.
+- 서버에서 docker-compose를 사용해 이미지를 배포합니다.
+
+
+# 도움말
+
+이 프로젝트를 포크하고 개선을 위한 PR(Pull Request)을 제출하세요.
+
+
+## 기여 가이드라인
+1. **브랜치 전략**:
+    - `feature/<feature-name>` 형식으로 기능 브랜치를 생성하세요.
+    - 버그 수정 시 `bugfix/<issue-name>` 형식을 사용하세요.
+
+
+2. **커밋 메시지 가이드라인**:
+    - 다음 형식을 사용하세요:
+      ```
+      <type>: <subject>
+      ```
+    - **type**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+    - 예시: `feat: add user authentication`
+
+
+3. **Pull Request**:
+    - 변경 사항을 자세히 설명하세요.
+    - 관련 이슈를 링크하세요 (예: `Close #1`).

--- a/src/main/java/io/spring/api/article/ArticleApi.java
+++ b/src/main/java/io/spring/api/article/ArticleApi.java
@@ -15,7 +15,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -45,6 +47,24 @@ public class ArticleApi {
           @Positive
           int size) {
     return ResponseEntity.ok(articleService.getArticles(page, size));
+  }
+
+  @GetMapping("/range")
+  public ResponseEntity<PaginatedListResponse<ArticleSummaryResponse>> getArticlesByDateRange(
+      @Parameter(description = "페이지 인덱스", example = "0", required = true)
+          @RequestParam(defaultValue = "0")
+          @PositiveOrZero
+          int page,
+      @Parameter(description = "응답 개수", example = "10", required = true)
+          @RequestParam(defaultValue = "10")
+          @Positive
+          int size,
+      @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime startDate,
+      @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime endDate) {
+    return ResponseEntity.ok(
+        articleService.findArticlesByDateRange(page, size, startDate, endDate));
   }
 
   @PostMapping

--- a/src/main/java/io/spring/application/article/ArticleService.java
+++ b/src/main/java/io/spring/application/article/ArticleService.java
@@ -14,6 +14,7 @@ import io.spring.core.article.domain.Tag;
 import io.spring.core.article.domain.TagRepository;
 import io.spring.core.user.domain.User;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -87,5 +88,16 @@ public class ArticleService {
     tagRepository.saveAll(tags);
 
     return article;
+  }
+
+  @Transactional(readOnly = true)
+  public PaginatedListResponse<ArticleSummaryResponse> findArticlesByDateRange(
+      int page, int size, LocalDateTime startDate, LocalDateTime endDate) {
+    Page<ArticleSummaryResponse> articlePage =
+        articleRepository.findAllByCreatedAtBetween(
+            startDate, endDate, PageRequest.of(page, size, Sort.by("createdAt").descending()));
+    return PaginatedListResponse.of(
+        articlePage.getContent(),
+        PageableResponse.of(articlePage.getPageable(), articlePage.getContent()));
   }
 }

--- a/src/main/java/io/spring/core/article/domain/Article.java
+++ b/src/main/java/io/spring/core/article/domain/Article.java
@@ -9,9 +9,11 @@ import io.spring.core.comment.domain.Comment;
 import io.spring.core.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -24,6 +26,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
+@Table(
+    name = "article",
+    indexes = {@Index(name = "idx_article_created_at", columnList = "created_at")})
 public class Article extends BaseTimeEntity {
 
   @JoinColumn(name = "author_id", nullable = false)
@@ -61,14 +66,14 @@ public class Article extends BaseTimeEntity {
   }
 
   public void update(String title, String description, String body) {
-    if (!title.isEmpty()) {
+    if (title != null && !title.isEmpty()) {
       this.title = title;
       this.slug = toSlug(title);
     }
-    if (!title.isEmpty()) {
+    if (description != null && !description.isEmpty()) {
       this.description = description;
     }
-    if (!title.isEmpty()) {
+    if (body != null && !body.isEmpty()) {
       this.body = body;
     }
   }

--- a/src/main/java/io/spring/core/article/domain/ArticleRepository.java
+++ b/src/main/java/io/spring/core/article/domain/ArticleRepository.java
@@ -1,6 +1,7 @@
 package io.spring.core.article.domain;
 
 import io.spring.api.article.response.ArticleSummaryResponse;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,4 +17,7 @@ public interface ArticleRepository {
   Article save(Article article);
 
   Page<ArticleSummaryResponse> findAllArticleSummary(Pageable pageable);
+
+  Page<ArticleSummaryResponse> findAllByCreatedAtBetween(
+      LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 }

--- a/src/main/java/io/spring/core/article/infrastructure/ArticleRepositoryImpl.java
+++ b/src/main/java/io/spring/core/article/infrastructure/ArticleRepositoryImpl.java
@@ -3,6 +3,7 @@ package io.spring.core.article.infrastructure;
 import io.spring.api.article.response.ArticleSummaryResponse;
 import io.spring.core.article.domain.Article;
 import io.spring.core.article.domain.ArticleRepository;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -38,5 +39,11 @@ public class ArticleRepositoryImpl implements ArticleRepository {
   @Override
   public Page<ArticleSummaryResponse> findAllArticleSummary(Pageable pageable) {
     return jpaArticleRepository.findAllArticleSummary(pageable);
+  }
+
+  @Override
+  public Page<ArticleSummaryResponse> findAllByCreatedAtBetween(
+      LocalDateTime startDate, LocalDateTime endDate, Pageable pageable) {
+    return jpaArticleRepository.findAllByCreatedAtBetween(startDate, endDate, pageable);
   }
 }

--- a/src/main/java/io/spring/core/article/infrastructure/JpaArticleRepository.java
+++ b/src/main/java/io/spring/core/article/infrastructure/JpaArticleRepository.java
@@ -2,12 +2,14 @@ package io.spring.core.article.infrastructure;
 
 import io.spring.api.article.response.ArticleSummaryResponse;
 import io.spring.core.article.domain.Article;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaArticleRepository extends JpaRepository<Article, UUID> {
   Optional<Article> findBySlug(String slug);
@@ -31,4 +33,28 @@ public interface JpaArticleRepository extends JpaRepository<Article, UUID> {
     JOIN a.author u
     """)
   Page<ArticleSummaryResponse> findAllArticleSummary(Pageable pageable);
+
+  @Query(
+      """
+		SELECT new io.spring.api.article.response.ArticleSummaryResponse(
+			a.slug,
+			a.title,
+			a.createdAt,
+			new io.spring.api.user.response.UserResponse(
+				u.id,
+				u.username,
+				u.bio,
+				u.image
+			),
+			(SELECT COUNT(t) FROM Tag t WHERE t.article.id = a.id),
+			(SELECT COUNT(c) FROM Comment c WHERE c.article.id = a.id)
+		)
+		FROM Article a
+		JOIN a.author u
+		WHERE a.createdAt BETWEEN :startDate AND :endDate
+		""")
+  Page<ArticleSummaryResponse> findAllByCreatedAtBetween(
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate,
+      Pageable pageable);
 }

--- a/src/main/java/io/spring/core/user/domain/User.java
+++ b/src/main/java/io/spring/core/user/domain/User.java
@@ -8,7 +8,9 @@ import io.spring.core.article.domain.Article;
 import io.spring.core.comment.domain.Comment;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -21,6 +23,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
+@Table(
+    name = "user",
+    indexes = {@Index(name = "idx_username", columnList = "username")})
 public class User extends BaseTimeEntity {
 
   @Column(nullable = false, unique = true)


### PR DESCRIPTION
## Summary

- close #1 
- created_at 컬럼 인덱싱을 통한 쿼리 성능 최적화

## Tasks

- PK, FK, UK 의 경우 자동으로 인덱스가 생성되어 현재의 간단한 프로젝트에서 인덱싱의 성능 비교가 유의미 하지 않아 `created_at` 컬럼에 대한 인덱스를 추가함
- `article` 테이블의 `created_at` 컬럼에 인덱스를 추가하여 날짜 기반 검색 쿼리의 성능을 최적화
-  `WHERE created_at BETWEEN ...` 조건의 쿼리 성능 개선:
-- 인덱스 적용 시: 평균 쿼리 실행 시간 15ms.
-- 인덱스 미적용 시: 평균 쿼리 실행 시간 174ms.

- README.md 수정
- README_ko.md 추가

## To Reviewer

- 100,000개의 `article` 데이터를 기반으로 로컬 테스트 수행.
- 100개의 동시 쓰레드로 부하 테스트 시뮬레이션 진행.
- `EXPLAIN`을 사용하여 쿼리 실행 계획을 확인하고 인덱스 활용 여부를 검증.

<img width="1145" alt="스크린샷 2025-01-10 오전 2 01 52" src="https://github.com/user-attachments/assets/fb43968f-79c3-468d-b2a8-982c0b0a6bbe" />
->
<img width="1145" alt="스크린샷 2025-01-10 오전 2 01 46" src="https://github.com/user-attachments/assets/f7aad69c-5512-4ab6-af8f-7200f17b4f64" />

